### PR TITLE
Configure EF Core context and payment service

### DIFF
--- a/PaymentApp2/PaymentApp2.csproj
+++ b/PaymentApp2/PaymentApp2.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.8" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
   </ItemGroup>
 

--- a/PaymentApp2/Program.cs
+++ b/PaymentApp2/Program.cs
@@ -1,6 +1,15 @@
+using Microsoft.EntityFrameworkCore;
+using PaymentApp.Data;
+using PaymentApp.Services;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
+
+builder.Services.AddDbContext<PaymentDbContext>(options =>
+    options.UseSqlServer(builder.Configuration.GetConnectionString("Default")));
+
+builder.Services.AddScoped<IPaymentService, PaymentService>();
 
 builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle

--- a/PaymentApp2/appsettings.Development.json
+++ b/PaymentApp2/appsettings.Development.json
@@ -1,4 +1,7 @@
 {
+  "ConnectionStrings": {
+    "Default": "Server=(localdb)\\mssqllocaldb;Database=PaymentDb;Trusted_Connection=True;MultipleActiveResultSets=true"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/PaymentApp2/appsettings.json
+++ b/PaymentApp2/appsettings.json
@@ -1,4 +1,7 @@
 {
+  "ConnectionStrings": {
+    "Default": "Server=(localdb)\\mssqllocaldb;Database=PaymentDb;Trusted_Connection=True;MultipleActiveResultSets=true"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
## Summary
- Register `PaymentDbContext` with SQL Server and add `PaymentService` for `IPaymentService`.
- Add Default connection string for SQL Server in both appsettings files.
- Include EF Core SQL Server provider package.

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_b_689dc17f1db0832abc5e0aeb0858bd1b