### PR TITLE
Add user-aware payment services and user CRUD endpoints

### DIFF
--- a/PaymentApp2/Controllers/PaymentsController.cs
+++ b/PaymentApp2/Controllers/PaymentsController.cs
@@ -1,11 +1,12 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Mvc;
 using PaymentApp.Models.DTOs;
 using PaymentApp.Services;
 
 namespace PaymentApp.Controllers
 {
     [ApiController]
-    [Route("api/[controller]")]
+    [Route("api/{userId?}/[controller]")]
     public class PaymentsController : ControllerBase
     {
         private readonly IPaymentService _paymentService;
@@ -15,131 +16,154 @@ namespace PaymentApp.Controllers
             _paymentService = paymentService;
         }
 
-        /// <summary>
-        /// Get all payments
-        /// </summary>
+        private int? GetUserId()
+        {
+            if (RouteData.Values.TryGetValue("userId", out var routeUser) && int.TryParse(routeUser?.ToString(), out var rid))
+                return rid;
+            if (Request.Query.TryGetValue("userId", out var queryUser) && int.TryParse(queryUser, out var qid))
+                return qid;
+            var claim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            if (int.TryParse(claim, out var cid))
+                return cid;
+            return null;
+        }
+
         [HttpGet]
         public async Task<ActionResult<IEnumerable<PaymentResponseDto>>> GetAllPayments()
         {
-            var payments = await _paymentService.GetAllPaymentsAsync();
+            var userId = GetUserId();
+            if (userId == null)
+                return BadRequest("UserId is required.");
+
+            var payments = await _paymentService.GetAllPaymentsAsync(userId.Value);
             return Ok(payments);
         }
 
-        /// <summary>
-        /// Get payment by ID
-        /// </summary>
         [HttpGet("{id}")]
         public async Task<ActionResult<PaymentResponseDto>> GetPayment(int id)
         {
-            var payment = await _paymentService.GetPaymentByIdAsync(id);
+            var userId = GetUserId();
+            if (userId == null)
+                return BadRequest("UserId is required.");
+
+            var payment = await _paymentService.GetPaymentByIdAsync(userId.Value, id);
             if (payment == null)
                 return NotFound($"Payment with ID {id} not found");
 
             return Ok(payment);
         }
 
-        /// <summary>
-        /// Create a new payment
-        /// </summary>
         [HttpPost]
         public async Task<ActionResult<PaymentResponseDto>> CreatePayment(CreatePaymentDto createDto)
         {
+            var userId = GetUserId();
+            if (userId == null)
+                return BadRequest("UserId is required.");
+
             if (!ModelState.IsValid)
                 return BadRequest(ModelState);
 
-            var payment = await _paymentService.CreatePaymentAsync(createDto);
-            return CreatedAtAction(nameof(GetPayment), new { id = payment.Id }, payment);
+            var payment = await _paymentService.CreatePaymentAsync(userId.Value, createDto);
+            return CreatedAtAction(nameof(GetPayment), new { id = payment.Id, userId = userId.Value }, payment);
         }
 
-        /// <summary>
-        /// Update an existing payment
-        /// </summary>
         [HttpPut("{id}")]
         public async Task<ActionResult<PaymentResponseDto>> UpdatePayment(int id, UpdatePaymentDto updateDto)
         {
+            var userId = GetUserId();
+            if (userId == null)
+                return BadRequest("UserId is required.");
+
             if (!ModelState.IsValid)
                 return BadRequest(ModelState);
 
-            var payment = await _paymentService.UpdatePaymentAsync(id, updateDto);
+            var payment = await _paymentService.UpdatePaymentAsync(userId.Value, id, updateDto);
             if (payment == null)
                 return NotFound($"Payment with ID {id} not found");
 
             return Ok(payment);
         }
 
-        /// <summary>
-        /// Delete a payment
-        /// </summary>
         [HttpDelete("{id}")]
         public async Task<ActionResult> DeletePayment(int id)
         {
-            var success = await _paymentService.DeletePaymentAsync(id);
+            var userId = GetUserId();
+            if (userId == null)
+                return BadRequest("UserId is required.");
+
+            var success = await _paymentService.DeletePaymentAsync(userId.Value, id);
             if (!success)
                 return NotFound($"Payment with ID {id} not found");
 
             return NoContent();
         }
 
-        /// <summary>
-        /// Mark a payment as paid
-        /// </summary>
         [HttpPost("{id}/mark-as-paid")]
         public async Task<ActionResult> MarkAsPaid(int id, MarkAsPaidDto markAsPaidDto)
         {
-            var success = await _paymentService.MarkAsPaidAsync(id, markAsPaidDto);
+            var userId = GetUserId();
+            if (userId == null)
+                return BadRequest("UserId is required.");
+
+            var success = await _paymentService.MarkAsPaidAsync(userId.Value, id, markAsPaidDto);
             if (!success)
                 return NotFound($"Payment with ID {id} not found");
 
             return Ok(new { message = "Payment marked as paid successfully" });
         }
 
-        /// <summary>
-        /// Get upcoming payments (next 30 days by default)
-        /// </summary>
         [HttpGet("upcoming")]
         public async Task<ActionResult<IEnumerable<PaymentResponseDto>>> GetUpcomingPayments([FromQuery] int days = 30)
         {
-            var payments = await _paymentService.GetUpcomingPaymentsAsync(days);
+            var userId = GetUserId();
+            if (userId == null)
+                return BadRequest("UserId is required.");
+
+            var payments = await _paymentService.GetUpcomingPaymentsAsync(userId.Value, days);
             return Ok(payments);
         }
 
-        /// <summary>
-        /// Get overdue payments
-        /// </summary>
         [HttpGet("overdue")]
         public async Task<ActionResult<IEnumerable<PaymentResponseDto>>> GetOverduePayments()
         {
-            var payments = await _paymentService.GetOverduePaymentsAsync();
+            var userId = GetUserId();
+            if (userId == null)
+                return BadRequest("UserId is required.");
+
+            var payments = await _paymentService.GetOverduePaymentsAsync(userId.Value);
             return Ok(payments);
         }
 
-        /// <summary>
-        /// Get payments due soon (next 7 days by default)
-        /// </summary>
         [HttpGet("due-soon")]
         public async Task<ActionResult<IEnumerable<PaymentResponseDto>>> GetDueSoonPayments([FromQuery] int days = 7)
         {
-            var payments = await _paymentService.GetDueSoonPaymentsAsync(days);
+            var userId = GetUserId();
+            if (userId == null)
+                return BadRequest("UserId is required.");
+
+            var payments = await _paymentService.GetDueSoonPaymentsAsync(userId.Value, days);
             return Ok(payments);
         }
 
-        /// <summary>
-        /// Get payment reminders (overdue + due soon)
-        /// </summary>
         [HttpGet("reminders")]
         public async Task<ActionResult<IEnumerable<PaymentResponseDto>>> GetReminders()
         {
-            var payments = await _paymentService.GetRemindersAsync();
+            var userId = GetUserId();
+            if (userId == null)
+                return BadRequest("UserId is required.");
+
+            var payments = await _paymentService.GetRemindersAsync(userId.Value);
             return Ok(payments);
         }
 
-        /// <summary>
-        /// Get payment summary statistics
-        /// </summary>
         [HttpGet("summary")]
         public async Task<ActionResult<PaymentSummaryDto>> GetPaymentSummary()
         {
-            var summary = await _paymentService.GetPaymentSummaryAsync();
+            var userId = GetUserId();
+            if (userId == null)
+                return BadRequest("UserId is required.");
+
+            var summary = await _paymentService.GetPaymentSummaryAsync(userId.Value);
             return Ok(summary);
         }
     }

--- a/PaymentApp2/Controllers/UsersController.cs
+++ b/PaymentApp2/Controllers/UsersController.cs
@@ -1,0 +1,66 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using PaymentApp.Data;
+using PaymentApp.Models;
+using PaymentApp.Models.DTOs;
+
+namespace PaymentApp.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class UsersController : ControllerBase
+{
+    private readonly PaymentDbContext _context;
+
+    public UsersController(PaymentDbContext context)
+    {
+        _context = context;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<UserResponseDto>>> GetUsers()
+    {
+        var users = await _context.Users.ToListAsync();
+        return Ok(users.Select(u => new UserResponseDto { Id = u.Id, Name = u.Name, Email = u.Email }));
+    }
+
+    [HttpGet("{id}")]
+    public async Task<ActionResult<UserResponseDto>> GetUser(int id)
+    {
+        var user = await _context.Users.FindAsync(id);
+        if (user == null) return NotFound();
+        return Ok(new UserResponseDto { Id = user.Id, Name = user.Name, Email = user.Email });
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<UserResponseDto>> CreateUser(CreateUserDto dto)
+    {
+        if (!ModelState.IsValid) return BadRequest(ModelState);
+        var user = new User { Name = dto.Name, Email = dto.Email };
+        _context.Users.Add(user);
+        await _context.SaveChangesAsync();
+        var response = new UserResponseDto { Id = user.Id, Name = user.Name, Email = user.Email };
+        return CreatedAtAction(nameof(GetUser), new { id = user.Id }, response);
+    }
+
+    [HttpPut("{id}")]
+    public async Task<ActionResult<UserResponseDto>> UpdateUser(int id, UpdateUserDto dto)
+    {
+        var user = await _context.Users.FindAsync(id);
+        if (user == null) return NotFound();
+        if (dto.Name != null) user.Name = dto.Name;
+        if (dto.Email != null) user.Email = dto.Email;
+        await _context.SaveChangesAsync();
+        return Ok(new UserResponseDto { Id = user.Id, Name = user.Name, Email = user.Email });
+    }
+
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> DeleteUser(int id)
+    {
+        var user = await _context.Users.FindAsync(id);
+        if (user == null) return NotFound();
+        _context.Users.Remove(user);
+        await _context.SaveChangesAsync();
+        return NoContent();
+    }
+}

--- a/PaymentApp2/Data/PaymentDbContext.cs
+++ b/PaymentApp2/Data/PaymentDbContext.cs
@@ -11,10 +11,24 @@ public class PaymentDbContext : DbContext
     }
 
     public DbSet<Payment> Payments { get; set; }
+    public DbSet<User> Users { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
+
+        // Configure User entity
+        modelBuilder.Entity<User>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Name).IsRequired().HasMaxLength(100);
+            entity.Property(e => e.Email).HasMaxLength(100);
+
+            entity.HasData(
+                new User { Id = 1, Name = "John Doe", Email = "john@example.com" },
+                new User { Id = 2, Name = "Jane Smith", Email = "jane@example.com" }
+            );
+        });
 
         // Configure Payment entity
         modelBuilder.Entity<Payment>(entity =>
@@ -24,12 +38,17 @@ public class PaymentDbContext : DbContext
             entity.Property(e => e.Amount).HasPrecision(18, 2);
 
             entity.Property(e => e.Notes).HasMaxLength(500);
-            
+
+            entity.HasOne(p => p.User)
+                .WithMany(u => u.Payments)
+                .HasForeignKey(p => p.UserId);
+
             // Add some sample data
             entity.HasData(
                 new Payment
                 {
                     Id = 1,
+                    UserId = 1,
                     Name = "Rent",
                     Amount = 1200.00m,
                     DueDate = DateTime.Today.AddDays(1),
@@ -40,6 +59,7 @@ public class PaymentDbContext : DbContext
                 new Payment
                 {
                     Id = 2,
+                    UserId = 1,
                     Name = "Electric Bill",
                     Amount = 85.50m,
                     DueDate = DateTime.Today.AddDays(15),
@@ -50,6 +70,7 @@ public class PaymentDbContext : DbContext
                 new Payment
                 {
                     Id = 3,
+                    UserId = 1,
                     Name = "Netflix Subscription",
                     Amount = 15.99m,
                     DueDate = DateTime.Today.AddDays(-2),
@@ -61,6 +82,7 @@ public class PaymentDbContext : DbContext
                 new Payment
                 {
                     Id = 4,
+                    UserId = 2,
                     Name = "Car Insurance",
                     Amount = 450.00m,
                     DueDate = DateTime.Today.AddDays(-5),
@@ -71,6 +93,7 @@ public class PaymentDbContext : DbContext
                 new Payment
                 {
                     Id = 5,
+                    UserId = 2,
                     Name = "Phone Bill",
                     Amount = 65.00m,
                     DueDate = DateTime.Today.AddDays(10),

--- a/PaymentApp2/Models/DTOs/PaymentDto.cs
+++ b/PaymentApp2/Models/DTOs/PaymentDto.cs
@@ -44,6 +44,7 @@ public class UpdatePaymentDto
 public class PaymentResponseDto
 {
     public int Id { get; set; }
+    public int UserId { get; set; }
     public string Name { get; set; } = string.Empty;
     public decimal Amount { get; set; }
     public DateTime DueDate { get; set; }

--- a/PaymentApp2/Models/DTOs/UserDto.cs
+++ b/PaymentApp2/Models/DTOs/UserDto.cs
@@ -1,0 +1,31 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace PaymentApp.Models.DTOs;
+
+public class CreateUserDto
+{
+    [Required]
+    [StringLength(100)]
+    public string Name { get; set; } = string.Empty;
+
+    [StringLength(100)]
+    [EmailAddress]
+    public string? Email { get; set; }
+}
+
+public class UpdateUserDto
+{
+    [StringLength(100)]
+    public string? Name { get; set; }
+
+    [StringLength(100)]
+    [EmailAddress]
+    public string? Email { get; set; }
+}
+
+public class UserResponseDto
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string? Email { get; set; }
+}

--- a/PaymentApp2/Models/Payment.cs
+++ b/PaymentApp2/Models/Payment.cs
@@ -28,6 +28,9 @@ public class Payment
     
     [StringLength(500)]
     public string? Notes { get; set; }
+
+    public int UserId { get; set; }
+    public User? User { get; set; }
     
     [NotMapped]
     public bool IsPaid => PaidDate.HasValue;

--- a/PaymentApp2/Models/User.cs
+++ b/PaymentApp2/Models/User.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace PaymentApp.Models;
+
+public class User
+{
+    [Key]
+    public int Id { get; set; }
+
+    [Required]
+    [StringLength(100)]
+    public string Name { get; set; } = string.Empty;
+
+    [StringLength(100)]
+    [EmailAddress]
+    public string? Email { get; set; }
+
+    public ICollection<Payment>? Payments { get; set; }
+}

--- a/PaymentApp2/PaymentApp2.csproj
+++ b/PaymentApp2/PaymentApp2.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.8" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
   </ItemGroup>
 

--- a/PaymentApp2/Program.cs
+++ b/PaymentApp2/Program.cs
@@ -1,6 +1,14 @@
+using Microsoft.EntityFrameworkCore;
+using PaymentApp.Data;
+using PaymentApp.Services;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
+
+builder.Services.AddDbContext<PaymentDbContext>(options =>
+    options.UseInMemoryDatabase("PaymentsDb"));
+builder.Services.AddScoped<IPaymentService, PaymentService>();
 
 builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle

--- a/PaymentApp2/Services/IPaymentService.cs
+++ b/PaymentApp2/Services/IPaymentService.cs
@@ -5,15 +5,15 @@ namespace PaymentApp.Services;
 
 public interface IPaymentService
 {
-    Task<IEnumerable<PaymentResponseDto>> GetAllPaymentsAsync();
-    Task<IEnumerable<PaymentResponseDto>> GetUpcomingPaymentsAsync(int days = 30);
-    Task<IEnumerable<PaymentResponseDto>> GetOverduePaymentsAsync();
-    Task<IEnumerable<PaymentResponseDto>> GetDueSoonPaymentsAsync(int days = 7);
-    Task<IEnumerable<PaymentResponseDto>> GetRemindersAsync();
-    Task<PaymentResponseDto?> GetPaymentByIdAsync(int id);
-    Task<PaymentResponseDto> CreatePaymentAsync(CreatePaymentDto createDto);
-    Task<PaymentResponseDto?> UpdatePaymentAsync(int id, UpdatePaymentDto updateDto);
-    Task<bool> DeletePaymentAsync(int id);
-    Task<bool> MarkAsPaidAsync(int id, MarkAsPaidDto markAsPaidDto);
-    Task<PaymentSummaryDto> GetPaymentSummaryAsync();
+    Task<IEnumerable<PaymentResponseDto>> GetAllPaymentsAsync(int userId);
+    Task<IEnumerable<PaymentResponseDto>> GetUpcomingPaymentsAsync(int userId, int days = 30);
+    Task<IEnumerable<PaymentResponseDto>> GetOverduePaymentsAsync(int userId);
+    Task<IEnumerable<PaymentResponseDto>> GetDueSoonPaymentsAsync(int userId, int days = 7);
+    Task<IEnumerable<PaymentResponseDto>> GetRemindersAsync(int userId);
+    Task<PaymentResponseDto?> GetPaymentByIdAsync(int userId, int id);
+    Task<PaymentResponseDto> CreatePaymentAsync(int userId, CreatePaymentDto createDto);
+    Task<PaymentResponseDto?> UpdatePaymentAsync(int userId, int id, UpdatePaymentDto updateDto);
+    Task<bool> DeletePaymentAsync(int userId, int id);
+    Task<bool> MarkAsPaidAsync(int userId, int id, MarkAsPaidDto markAsPaidDto);
+    Task<PaymentSummaryDto> GetPaymentSummaryAsync(int userId);
 }

--- a/PaymentApp2/Services/PaymentService.cs
+++ b/PaymentApp2/Services/PaymentService.cs
@@ -14,72 +14,74 @@ public class PaymentService : IPaymentService
         _context = context;
     }
     
-    public async Task<IEnumerable<PaymentResponseDto>> GetAllPaymentsAsync()
+    public async Task<IEnumerable<PaymentResponseDto>> GetAllPaymentsAsync(int userId)
     {
         var payments = await _context.Payments
+            .Where(p => p.UserId == userId)
             .OrderBy(p => p.DueDate)
             .ToListAsync();
-            
+
         return payments.Select(MapToResponseDto);
     }
-    
-    public async Task<IEnumerable<PaymentResponseDto>> GetUpcomingPaymentsAsync(int days = 30)
-    {
-        var cutoffDate = DateTime.Today.AddDays(days);
-        var payments = await _context.Payments
-            .Where(p => !p.PaidDate.HasValue && p.DueDate <= cutoffDate)
-            .OrderBy(p => p.DueDate)
-            .ToListAsync();
-            
-        return payments.Select(MapToResponseDto);
-    }
-    
-    public async Task<IEnumerable<PaymentResponseDto>> GetOverduePaymentsAsync()
-    {
-        var payments = await _context.Payments
-            .Where(p => !p.PaidDate.HasValue && p.DueDate < DateTime.Today)
-            .OrderBy(p => p.DueDate)
-            .ToListAsync();
-            
-        return payments.Select(MapToResponseDto);
-    }
-    
-    public async Task<IEnumerable<PaymentResponseDto>> GetDueSoonPaymentsAsync(int days = 7)
+
+    public async Task<IEnumerable<PaymentResponseDto>> GetUpcomingPaymentsAsync(int userId, int days = 30)
     {
         var cutoffDate = DateTime.Today.AddDays(days);
         var payments = await _context.Payments
-            .Where(p => !p.PaidDate.HasValue && p.DueDate <= cutoffDate && p.DueDate >= DateTime.Today)
+            .Where(p => p.UserId == userId && !p.PaidDate.HasValue && p.DueDate <= cutoffDate)
             .OrderBy(p => p.DueDate)
             .ToListAsync();
-            
+
         return payments.Select(MapToResponseDto);
     }
-    
-    public async Task<IEnumerable<PaymentResponseDto>> GetRemindersAsync()
+
+    public async Task<IEnumerable<PaymentResponseDto>> GetOverduePaymentsAsync(int userId)
+    {
+        var payments = await _context.Payments
+            .Where(p => p.UserId == userId && !p.PaidDate.HasValue && p.DueDate < DateTime.Today)
+            .OrderBy(p => p.DueDate)
+            .ToListAsync();
+
+        return payments.Select(MapToResponseDto);
+    }
+
+    public async Task<IEnumerable<PaymentResponseDto>> GetDueSoonPaymentsAsync(int userId, int days = 7)
+    {
+        var cutoffDate = DateTime.Today.AddDays(days);
+        var payments = await _context.Payments
+            .Where(p => p.UserId == userId && !p.PaidDate.HasValue && p.DueDate <= cutoffDate && p.DueDate >= DateTime.Today)
+            .OrderBy(p => p.DueDate)
+            .ToListAsync();
+
+        return payments.Select(MapToResponseDto);
+    }
+
+    public async Task<IEnumerable<PaymentResponseDto>> GetRemindersAsync(int userId)
     {
         var reminders = new List<PaymentResponseDto>();
-        
+
         // Overdue payments
-        var overduePayments = await GetOverduePaymentsAsync();
+        var overduePayments = await GetOverduePaymentsAsync(userId);
         reminders.AddRange(overduePayments);
-        
+
         // Due in next 3 days
-        var dueSoonPayments = await GetDueSoonPaymentsAsync(3);
+        var dueSoonPayments = await GetDueSoonPaymentsAsync(userId, 3);
         reminders.AddRange(dueSoonPayments);
-        
+
         return reminders.OrderBy(p => p.DueDate);
     }
-    
-    public async Task<PaymentResponseDto?> GetPaymentByIdAsync(int id)
+
+    public async Task<PaymentResponseDto?> GetPaymentByIdAsync(int userId, int id)
     {
-        var payment = await _context.Payments.FindAsync(id);
+        var payment = await _context.Payments.FirstOrDefaultAsync(p => p.Id == id && p.UserId == userId);
         return payment != null ? MapToResponseDto(payment) : null;
     }
-    
-    public async Task<PaymentResponseDto> CreatePaymentAsync(CreatePaymentDto createDto)
+
+    public async Task<PaymentResponseDto> CreatePaymentAsync(int userId, CreatePaymentDto createDto)
     {
         var payment = new Payment
         {
+            UserId = userId,
             Name = createDto.Name,
             Amount = createDto.Amount,
             DueDate = createDto.DueDate,
@@ -87,18 +89,18 @@ public class PaymentService : IPaymentService
             RecurrenceType = createDto.RecurrenceType,
             Notes = createDto.Notes
         };
-        
+
         _context.Payments.Add(payment);
         await _context.SaveChangesAsync();
-        
+
         return MapToResponseDto(payment);
     }
-    
-    public async Task<PaymentResponseDto?> UpdatePaymentAsync(int id, UpdatePaymentDto updateDto)
+
+    public async Task<PaymentResponseDto?> UpdatePaymentAsync(int userId, int id, UpdatePaymentDto updateDto)
     {
-        var payment = await _context.Payments.FindAsync(id);
+        var payment = await _context.Payments.FirstOrDefaultAsync(p => p.Id == id && p.UserId == userId);
         if (payment == null) return null;
-        
+
         if (updateDto.Name != null)
             payment.Name = updateDto.Name;
         if (updateDto.Amount.HasValue)
@@ -111,47 +113,47 @@ public class PaymentService : IPaymentService
             payment.RecurrenceType = updateDto.RecurrenceType.Value;
         if (updateDto.Notes != null)
             payment.Notes = updateDto.Notes;
-        
+
         await _context.SaveChangesAsync();
         return MapToResponseDto(payment);
     }
-    
-    public async Task<bool> DeletePaymentAsync(int id)
+
+    public async Task<bool> DeletePaymentAsync(int userId, int id)
     {
-        var payment = await _context.Payments.FindAsync(id);
+        var payment = await _context.Payments.FirstOrDefaultAsync(p => p.Id == id && p.UserId == userId);
         if (payment == null) return false;
-        
+
         _context.Payments.Remove(payment);
         await _context.SaveChangesAsync();
         return true;
     }
-    
-    public async Task<bool> MarkAsPaidAsync(int id, MarkAsPaidDto markAsPaidDto)
+
+    public async Task<bool> MarkAsPaidAsync(int userId, int id, MarkAsPaidDto markAsPaidDto)
     {
-        var payment = await _context.Payments.FindAsync(id);
+        var payment = await _context.Payments.FirstOrDefaultAsync(p => p.Id == id && p.UserId == userId);
         if (payment == null) return false;
-        
+
         payment.PaidDate = markAsPaidDto.PaidDate ?? DateTime.Today;
-        
+
         // If recurring, create next payment
         if (payment.IsRecurring && payment.RecurrenceType != RecurrenceType.None)
         {
             var nextPayment = CreateNextRecurringPayment(payment);
             _context.Payments.Add(nextPayment);
         }
-        
+
         await _context.SaveChangesAsync();
         return true;
     }
-    
-    public async Task<PaymentSummaryDto> GetPaymentSummaryAsync()
+
+    public async Task<PaymentSummaryDto> GetPaymentSummaryAsync(int userId)
     {
-        var allPayments = await _context.Payments.ToListAsync();
+        var allPayments = await _context.Payments.Where(p => p.UserId == userId).ToListAsync();
         var paidPayments = allPayments.Where(p => p.PaidDate.HasValue);
         var unpaidPayments = allPayments.Where(p => !p.PaidDate.HasValue);
         var overduePayments = allPayments.Where(p => !p.PaidDate.HasValue && p.DueDate < DateTime.Today);
         var dueSoonPayments = allPayments.Where(p => !p.PaidDate.HasValue && (p.DueDate - DateTime.Today).Days <= 7);
-        
+
         return new PaymentSummaryDto
         {
             TotalPayments = allPayments.Count,
@@ -182,15 +184,17 @@ public class PaymentService : IPaymentService
             DueDate = nextDueDate,
             IsRecurring = originalPayment.IsRecurring,
             RecurrenceType = originalPayment.RecurrenceType,
-            Notes = originalPayment.Notes
+            Notes = originalPayment.Notes,
+            UserId = originalPayment.UserId
         };
     }
-    
+
     private static PaymentResponseDto MapToResponseDto(Payment payment)
     {
         return new PaymentResponseDto
         {
             Id = payment.Id,
+            UserId = payment.UserId,
             Name = payment.Name,
             Amount = payment.Amount,
             DueDate = payment.DueDate,


### PR DESCRIPTION
## Summary
- associate payments with users and seed sample users
- require userId in payment service operations and surface userId in DTOs
- expose user-aware payment routes and basic user CRUD controller

## Testing
- `dotnet build`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_b_689dc17df408832a965397d508f04f45